### PR TITLE
[GoFr-SOC] Added Download Button for Certificate Page

### DIFF
--- a/src/app/certificate/[id]/page.js
+++ b/src/app/certificate/[id]/page.js
@@ -1,29 +1,56 @@
-import NotFound from '@/app/not-found'
-import Image from 'next/image'
+'use client';
 
-async function getCertificateUrl(id) {
-  const response = await fetch(`https://gofr.dev/certificate-service/certificate/${id}`)
-  const { data } = await response.json()
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import html2canvas from 'html2canvas';
 
-  return data.url
-}
+export default function Certificate({ params }) {
+  const [certificateUrl, setCertificateUrl] = useState(null);
 
-export default async function Certificate({ params }) {
-  try {
-    const certificateUrl = await getCertificateUrl(params.id)
+  useEffect(() => {
+    const fetchCertificate = async () => {
+      const response = await fetch(`https://gofr.dev/certificate-service/certificate/${params.id}`);
+      const { data } = await response.json();
+      setCertificateUrl(data.url);
+    };
 
-    return (
-      <Image
-        className="mx-auto w-[90%] max-w-5xl"
-        src={certificateUrl}
-        alt="certificate"
-        height={600}
-        width={800}
-        unoptimized
-        priority
-      />
-    )
-  } catch (error) {
-    return <NotFound />
-  }
+    fetchCertificate();
+  }, [params.id]);
+
+  const handleDownload = () => {
+    const element = document.getElementById('certificate-container');
+    if (!element) return;
+
+    html2canvas(element).then((canvas) => {
+      const link = document.createElement('a');
+      link.download = 'certificate.png';
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    });
+  };
+
+  if (!certificateUrl) return <p className="text-center mt-10">Loading certificate...</p>;
+
+  return (
+    <div className="text-center mt-6">
+      <button
+        onClick={handleDownload}
+        className="mb-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+      >
+        Download Certificate
+      </button>
+
+      <div id="certificate-container">
+        <Image
+          className="mx-auto w-[90%] max-w-5xl"
+          src={certificateUrl}
+          alt="certificate"
+          height={600}
+          width={800}
+          unoptimized
+          priority
+        />
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
- Converted the certificate page from a server component to a client component
- Fetched certificate image using useEffect for client-side rendering
- Added a download button above the certificate image
- Used html2canvas to allow users to download the certificate as PNG